### PR TITLE
feat: add support for arm64 prologues

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,22 @@ It works with raw bytes from any binary format as well as parsing ELF files.
 - **Prologue-Based Detection**: Recognizes common function entry patterns by instruction analysis
 - **Format-Agnostic Core**: Works on raw machine code bytes from any binary format
 - **ELF Convenience Wrapper**: Built-in support for parsing ELF executables
-- **Pattern Classification**: Labels detected prologues by type (classic, no-frame-pointer, push-only, lea-based)
+- **Pattern Classification**: Labels detected prologues by type
 
 ## Supported architectures
 
 - **x86_64** (AMD64)
+- **ARM64** (AArch64)
 
-## Function Metadata
+## Supported function metadata
 
-### Prologues
+### Function prologues
 
 Prologues are one of the metadata that prologo recovers about functions. They are detected by recognizing common instruction patterns at function entry points.
+
+#### x86_64
+
+On x86_64, the `CALL` instruction pushes the return address onto the stack automatically. RBP serves as the frame pointer (pointing to the base of the current stack frame) and RSP is the stack pointer. Functions typically save the caller's RBP and establish a new frame to create a linked list of stack frames that debuggers and unwinders can walk.
 
 #### 1. Classic Frame Pointer Setup (`classic`)
 
@@ -27,30 +32,63 @@ Prologues are one of the metadata that prologo recovers about functions. They ar
 push rbp        ; Save caller's frame pointer
 mov rbp, rsp    ; Set up new frame pointer
 ```
-Traditional prologue that establishes a complete stack frame with base pointer.
-Used by: Non-optimized builds (`-O0`), code with `-fno-omit-frame-pointer`
+`push rbp` saves the caller's frame pointer onto the stack. `mov rbp, rsp` then sets RBP to the current stack top, establishing the base of the new frame. Together they link this frame to the caller's frame, creating a chain that debuggers and stack unwinders traverse. This is the standard prologue in non-optimized builds (`-O0`) and code compiled with `-fno-omit-frame-pointer`.
 
 #### 2. No-Frame-Pointer Function (`no-frame-pointer`)
 
 ```asm
 sub rsp, 0x20   ; Allocate stack space directly
 ```
-Optimized prologue that skips frame pointer setup entirely.
-Used by: Optimized builds (`-O2`, `-O3`), `-fomit-frame-pointer` flag
+Optimizing compilers skip the frame pointer setup to free RBP as a general-purpose register, gaining a slight performance benefit. `sub rsp, imm` directly allocates stack space without establishing a frame chain. Stack unwinding relies on DWARF `.eh_frame` unwind tables instead. Common in optimized builds (`-O2`, `-O3`) or with `-fomit-frame-pointer`.
 
 #### 3. Push-Only Prologue (`push-only`)
 
 ```asm
 push rbp        ; Save frame pointer only
 ```
-Minimal prologue that saves RBP but doesn't establish a frame chain.
+`push rbp` saves the caller's frame pointer but the function never executes `mov rbp, rsp`, so no frame chain is established. This may appear in leaf functions or as part of callee-saved register preservation where RBP is used as a general-purpose register.
 
 #### 4. LEA-Based Stack Allocation (`lea-based`)
 
 ```asm
 lea rsp, [rsp-0x20]   ; Allocate using LEA instead of SUB
 ```
-Alternative stack allocation using LEA instruction. LEA doesn't modify CPU flags (unlike SUB).
+Achieves the same stack allocation as `sub rsp, 0x20` but without modifying the CPU flags register (RFLAGS). The compiler emits this when it needs to preserve flags across the stack allocation — for example, when a conditional branch depends on flags set before the prologue.
+
+#### ARM64
+
+Unlike x86_64, ARM64's `BL` (Branch with Link) instruction does not push the return address onto the stack — it stores it in **x30**, the link register (LR). The callee must explicitly save x30 to the stack if it needs to call other functions, otherwise the return address is overwritten. **x29** is the frame pointer (equivalent of RBP), used to build a chain of stack frames for unwinding.
+
+ARM64 uses **STP** (Store Pair) to write two 64-bit registers to adjacent memory slots in a single instruction. Pre-index addressing (the `!` suffix) means the base register (SP) is decremented *before* the store takes place.
+
+#### 1. STP Frame Pair (`stp-frame-pair`)
+
+```asm
+stp x29, x30, [sp, #-N]!   ; Save frame pointer and link register
+mov x29, sp                  ; Set up new frame pointer
+```
+`stp x29, x30, [sp, #-N]!` decrements SP by N, then stores x29 (frame pointer) at `[SP]` and x30 (return address) at `[SP+8]` in one instruction. `mov x29, sp` then establishes the new frame pointer, creating a frame chain for stack unwinding. This is the standard AArch64 prologue emitted by C compilers (GCC, Clang) — the equivalent of x86's `push rbp; mov rbp, rsp`.
+
+#### 2. STR LR Pre-Index (`str-lr-preindex`)
+
+```asm
+str x30, [sp, #-N]!   ; Save link register with stack allocation
+```
+Go's ARM64 calling convention differs from the standard AAPCS64. Instead of using STP to save both registers at once, Go saves x30 (the link register) alone with a pre-indexed store, then separately saves x29 with `STUR X29, [SP, #-8]` and sets up the frame pointer with `SUB X29, SP, #8`. This is the dominant prologue pattern in Go-compiled ARM64 binaries.
+
+#### 3. Sub SP (`sub-sp`)
+
+```asm
+sub sp, sp, #N   ; Allocate stack space directly
+```
+Allocates stack space without saving any registers or setting up a frame pointer. The ARM64 equivalent of x86_64's no-frame-pointer pattern. Appears in leaf functions or when the compiler omits frame pointers.
+
+#### 4. STP-Only (`stp-only`)
+
+```asm
+stp x29, x30, [sp, #-N]!   ; Save FP and LR only
+```
+The STP saves both x29 and x30 to the stack, but the function does not execute `mov x29, sp` afterward. The registers are preserved for restoration on return, but no frame chain is established — stack unwinding cannot follow frame pointers through this function.
 
 ## Usage
 
@@ -100,22 +138,40 @@ func main() {
 
 ```go
 // Core detection — works on raw machine code bytes, no I/O.
-func DetectPrologues(code []byte, baseAddr uint64) ([]Prologue, error)
+// arch selects architecture-specific detection logic.
+func DetectPrologues(code []byte, baseAddr uint64, arch Arch) ([]Prologue, error)
 
 // Convenience wrapper — parses ELF from the reader, extracts .text, calls DetectPrologues.
+// Architecture is inferred from the ELF header.
 func DetectProloguesFromELF(r io.ReaderAt) ([]Prologue, error)
 ```
 
 **Types:**
 
 ```go
-type PrologueType string
+type Arch string
 
 const (
-    PrologueClassic   PrologueType = "classic"
+    ArchAMD64 Arch = "amd64"
+    ArchARM64 Arch = "arm64"
+)
+
+type PrologueType string
+
+// x86_64 prologue types
+const (
+    PrologueClassic        PrologueType = "classic"
     PrologueNoFramePointer PrologueType = "no-frame-pointer"
-    ProloguePushOnly  PrologueType = "push-only"
-    PrologueLEABased  PrologueType = "lea-based"
+    ProloguePushOnly       PrologueType = "push-only"
+    PrologueLEABased       PrologueType = "lea-based"
+)
+
+// ARM64 prologue types
+const (
+    PrologueSTPFramePair  PrologueType = "stp-frame-pair"
+    PrologueSTRLRPreIndex PrologueType = "str-lr-preindex"
+    PrologueSubSP         PrologueType = "sub-sp"
+    PrologueSTPOnly       PrologueType = "stp-only"
 )
 
 type Prologue struct {
@@ -125,11 +181,11 @@ type Prologue struct {
 }
 ```
 
-`DetectPrologues` accepts raw bytes and a base virtual address, making it format-agnostic (works with ELF, PE, Mach-O, raw dumps).
+`DetectPrologues` accepts raw bytes, a base virtual address, and a target architecture, making it format-agnostic (works with ELF, PE, Mach-O, raw dumps).
 
-`DetectProloguesFromELF` accepts an `io.ReaderAt` (e.g. `*os.File`) and handles ELF parsing internally.
+`DetectProloguesFromELF` accepts an `io.ReaderAt` (e.g. `*os.File`), infers the architecture from the ELF header, and handles parsing internally.
 
-## Implementation Details
+## Implementation
 
 ### Architecture
 
@@ -146,7 +202,7 @@ type Prologue struct {
          │
          ▼
 ┌─────────────────┐
-│  Disassembler   │ ← golang.org/x/arch/x86/x86asm
+│  Disassembler   │ ← golang.org/x/arch (x86asm / arm64asm)
 │   (ASM decode)  │
 └────────┬────────┘
          │
@@ -163,7 +219,7 @@ type Prologue struct {
 └─────────────────┘
 ```
 
-### Limitations
+## Limitations
 
 - **No Symbol Information**: Works on stripped binaries but reports addresses only
 - **Heuristic-Based**: May have false positives in data sections or inline data
@@ -173,13 +229,15 @@ type Prologue struct {
 ## Dependencies
 
 - **Go 1.21+**
-- [`golang.org/x/arch/x86/x86asm`](https://pkg.go.dev/golang.org/x/arch/x86/x86asm) - x86 disassembler
+- [`golang.org/x/arch`](https://pkg.go.dev/golang.org/x/arch) - x86 and ARM64 disassembler
 - `debug/elf` (standard library) - ELF parser
 
 ## References
 
 - [System V AMD64 ABI](https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf)
+- [ARM Architecture Reference Manual](https://developer.arm.com/documentation/ddi0487/latest)
 - [Intel 64 and IA-32 Architectures Software Developer Manuals](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)
 - [Go x86 Assembler](https://pkg.go.dev/golang.org/x/arch/x86/x86asm)
+- [Go ARM64 Assembler](https://pkg.go.dev/golang.org/x/arch/arm64/arm64asm)
 - [ELF Format Specification](https://refspecs.linuxfoundation.org/elf/elf.pdf)
 

--- a/detector.go
+++ b/detector.go
@@ -5,13 +5,26 @@ import (
 	"fmt"
 	"io"
 
+	"golang.org/x/arch/arm64/arm64asm"
 	"golang.org/x/arch/x86/x86asm"
 )
 
 // DetectPrologues analyzes raw machine code bytes and returns detected function
 // prologues. baseAddr is the virtual address corresponding to the start of code.
+// arch selects the architecture-specific detection logic.
 // This function performs no I/O and works with any binary format.
-func DetectPrologues(code []byte, baseAddr uint64) ([]Prologue, error) {
+func DetectPrologues(code []byte, baseAddr uint64, arch Arch) ([]Prologue, error) {
+	switch arch {
+	case ArchAMD64:
+		return detectProloguesAMD64(code, baseAddr)
+	case ArchARM64:
+		return detectProloguesARM64(code, baseAddr)
+	default:
+		return nil, fmt.Errorf("unsupported architecture: %s", arch)
+	}
+}
+
+func detectProloguesAMD64(code []byte, baseAddr uint64) ([]Prologue, error) {
 	var result []Prologue
 
 	offset := 0
@@ -81,8 +94,101 @@ func DetectPrologues(code []byte, baseAddr uint64) ([]Prologue, error) {
 	return result, nil
 }
 
+// isSTPx29x30PreIndex checks if an ARM64 instruction is stp x29, x30, [sp, #-N]!
+func isSTPx29x30PreIndex(inst arm64asm.Inst) bool {
+	if inst.Op != arm64asm.STP {
+		return false
+	}
+	r0, ok0 := inst.Args[0].(arm64asm.Reg)
+	r1, ok1 := inst.Args[1].(arm64asm.Reg)
+	mem, ok2 := inst.Args[2].(arm64asm.MemImmediate)
+	return ok0 && ok1 && ok2 &&
+		r0 == arm64asm.X29 && r1 == arm64asm.X30 &&
+		mem.Mode == arm64asm.AddrPreIndex
+}
+
+// isMovX29SP checks if an ARM64 instruction is mov x29, sp.
+// The disassembler decodes this as MOV with both args as RegSP.
+func isMovX29SP(inst arm64asm.Inst) bool {
+	if inst.Op != arm64asm.MOV {
+		return false
+	}
+	r0, ok0 := inst.Args[0].(arm64asm.RegSP)
+	r1, ok1 := inst.Args[1].(arm64asm.RegSP)
+	return ok0 && ok1 && r0 == arm64asm.RegSP(arm64asm.X29) && r1 == arm64asm.RegSP(arm64asm.SP)
+}
+
+func detectProloguesARM64(code []byte, baseAddr uint64) ([]Prologue, error) {
+	var result []Prologue
+
+	const insnLen = 4
+	var prevInsn *arm64asm.Inst
+
+	for offset := 0; offset+insnLen <= len(code); offset += insnLen {
+		inst, err := arm64asm.Decode(code[offset : offset+insnLen])
+		if err != nil {
+			prevInsn = nil
+			continue
+		}
+		addr := baseAddr + uint64(offset)
+
+		if prevInsn != nil && isSTPx29x30PreIndex(*prevInsn) {
+			if isMovX29SP(inst) {
+				// Pattern 1: STP frame pair - stp x29, x30, [sp, #-N]! ; mov x29, sp
+				result = append(result, Prologue{
+					Address:      addr - insnLen,
+					Type:         PrologueSTPFramePair,
+					Instructions: "stp x29, x30, [sp, #-N]!; mov x29, sp",
+				})
+			} else {
+				// Pattern 3: STP-only - stp x29, x30, [sp, #-N]! without mov x29, sp
+				result = append(result, Prologue{
+					Address:      addr - insnLen,
+					Type:         PrologueSTPOnly,
+					Instructions: "stp x29, x30, [sp, #-N]!",
+				})
+			}
+		}
+
+		// Pattern 2: STR LR pre-index - str x30, [sp, #-N]! (Go-style prologue)
+		if inst.Op == arm64asm.STR {
+			if r0, ok := inst.Args[0].(arm64asm.Reg); ok && r0 == arm64asm.X30 {
+				if mem, ok := inst.Args[1].(arm64asm.MemImmediate); ok && mem.Mode == arm64asm.AddrPreIndex {
+					if prevInsn == nil || prevInsn.Op == arm64asm.RET {
+						result = append(result, Prologue{
+							Address:      addr,
+							Type:         PrologueSTRLRPreIndex,
+							Instructions: fmt.Sprintf("str x30, %s", inst.Args[1]),
+						})
+					}
+				}
+			}
+		}
+
+		// Pattern 3: Sub SP - sub sp, sp, #N (stack allocation without frame pointer)
+		if inst.Op == arm64asm.SUB {
+			if dst, ok := inst.Args[0].(arm64asm.RegSP); ok && dst == arm64asm.RegSP(arm64asm.SP) {
+				if src, ok := inst.Args[1].(arm64asm.RegSP); ok && src == arm64asm.RegSP(arm64asm.SP) {
+					if prevInsn == nil || prevInsn.Op == arm64asm.RET {
+						result = append(result, Prologue{
+							Address:      addr,
+							Type:         PrologueSubSP,
+							Instructions: fmt.Sprintf("sub sp, sp, #%s", inst.Args[2]),
+						})
+					}
+				}
+			}
+		}
+
+		prevInsn = &inst
+	}
+
+	return result, nil
+}
+
 // DetectProloguesFromELF parses an ELF binary from the given reader, extracts
 // the .text section, and returns detected function prologues.
+// The architecture is inferred from the ELF header.
 func DetectProloguesFromELF(r io.ReaderAt) ([]Prologue, error) {
 	f, err := elf.NewFile(r)
 	if err != nil {
@@ -100,5 +206,12 @@ func DetectProloguesFromELF(r io.ReaderAt) ([]Prologue, error) {
 		return nil, fmt.Errorf("failed to read .text section: %w", err)
 	}
 
-	return DetectPrologues(code, textSec.Addr)
+	switch f.Machine {
+	case elf.EM_X86_64:
+		return detectProloguesAMD64(code, textSec.Addr)
+	case elf.EM_AARCH64:
+		return detectProloguesARM64(code, textSec.Addr)
+	default:
+		return nil, fmt.Errorf("unsupported ELF machine: %s", f.Machine)
+	}
 }

--- a/detector_test.go
+++ b/detector_test.go
@@ -2,6 +2,7 @@ package prologo_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,7 +16,13 @@ const (
 	demoAppBinary = "demo-app"
 )
 
-func TestDetectPrologues(t *testing.T) {
+func TestDetectProloguesAMD64(t *testing.T) {
+	// AMD64 instruction encodings:
+	// nop                       = 0x90
+	// push rbp                  = 0x55
+	// mov rbp, rsp              = 0x48 0x89 0xe5
+	// sub rsp, 0x20             = 0x48 0x83 0xec 0x20
+
 	tests := []struct {
 		name      string
 		code      []byte
@@ -73,7 +80,7 @@ func TestDetectPrologues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prologues, err := prologo.DetectPrologues(tt.code, tt.baseAddr)
+			prologues, err := prologo.DetectPrologues(tt.code, tt.baseAddr, prologo.ArchAMD64)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -94,25 +101,155 @@ func TestDetectPrologues(t *testing.T) {
 	}
 }
 
+// arm64Insn encodes an ARM64 instruction as little-endian bytes.
+func arm64Insn(insns ...uint32) []byte {
+	buf := make([]byte, 4*len(insns))
+	for i, insn := range insns {
+		binary.LittleEndian.PutUint32(buf[i*4:], insn)
+	}
+	return buf
+}
+
+func TestDetectProloguesARM64(t *testing.T) {
+	// ARM64 instruction encodings (little-endian):
+	// stp x29, x30, [sp, #-16]! = 0xa9bf7bfd
+	// mov x29, sp               = 0x910003fd
+	// sub sp, sp, #0x20         = 0xd10083ff
+	// nop                       = 0xd503201f
+	// ret                       = 0xd65f03c0
+
+	stpX29X30 := uint32(0xa9bf7bfd) // stp x29, x30, [sp, #-16]!
+	movX29SP := uint32(0x910003fd)  // mov x29, sp
+	subSP := uint32(0xd10083ff)     // sub sp, sp, #0x20
+	strX30 := uint32(0xf81e0ffe)    // str x30, [sp, #-32]!
+	nop := uint32(0xd503201f)       // nop
+
+	tests := []struct {
+		name      string
+		code      []byte
+		baseAddr  uint64
+		wantCount int
+		wantType  prologo.PrologueType
+		wantAddr  uint64
+	}{
+		{
+			name:      string(prologo.PrologueSTPFramePair),
+			code:      arm64Insn(stpX29X30, movX29SP),
+			baseAddr:  0,
+			wantCount: 1,
+			wantType:  prologo.PrologueSTPFramePair,
+			wantAddr:  0,
+		},
+		{
+			name:      string(prologo.PrologueSTRLRPreIndex),
+			code:      arm64Insn(strX30),
+			baseAddr:  0,
+			wantCount: 1,
+			wantType:  prologo.PrologueSTRLRPreIndex,
+			wantAddr:  0,
+		},
+		{
+			name:      string(prologo.PrologueSubSP),
+			code:      arm64Insn(subSP),
+			baseAddr:  0,
+			wantCount: 1,
+			wantType:  prologo.PrologueSubSP,
+			wantAddr:  0,
+		},
+		{
+			// stp x29, x30, [sp, #-16]! followed by nop (not mov x29, sp)
+			name:      string(prologo.PrologueSTPOnly),
+			code:      arm64Insn(stpX29X30, nop),
+			baseAddr:  0,
+			wantCount: 1,
+			wantType:  prologo.PrologueSTPOnly,
+			wantAddr:  0,
+		},
+		{
+			name:      "ARM64_EmptyNil",
+			code:      nil,
+			wantCount: 0,
+		},
+		{
+			name:      "ARM64_EmptySlice",
+			code:      []byte{},
+			wantCount: 0,
+		},
+		{
+			name:      "ARM64_InvalidBytes",
+			code:      []byte{0xde, 0xad, 0xbe, 0xef},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prologues, err := prologo.DetectPrologues(tt.code, tt.baseAddr, prologo.ArchARM64)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(prologues) != tt.wantCount {
+				t.Fatalf("expected %d prologue(s), got %d: %+v", tt.wantCount, len(prologues), prologues)
+			}
+			if tt.wantCount == 0 {
+				return
+			}
+			if prologues[0].Type != tt.wantType {
+				t.Errorf("expected type %s, got %s", tt.wantType, prologues[0].Type)
+			}
+			if prologues[0].Address != tt.wantAddr {
+				t.Errorf("expected address 0x%x, got 0x%x", tt.wantAddr, prologues[0].Address)
+			}
+		})
+	}
+}
+
+func TestDetectPrologues_UnsupportedArch(t *testing.T) {
+	_, err := prologo.DetectPrologues([]byte{0x00}, 0, prologo.Arch("mips"))
+	if err == nil {
+		t.Fatal("expected error for unsupported architecture, got nil")
+	}
+}
+
 func TestDetectProloguesFromELF(t *testing.T) {
 	tests := []struct {
 		name      string
-		buildArgs []string                        // extra args after "go build -o <path>"
-		minCounts map[prologo.PrologueType]int // minimum prologues per type
+		goarch    string
+		buildArgs []string
+		minCounts map[prologo.PrologueType]int
 	}{
 		{
-			name:      "optimized",
+			name:      "amd64/optimized",
+			goarch:    "amd64",
 			buildArgs: nil,
 			minCounts: map[prologo.PrologueType]int{
-				prologo.PrologueClassic:   1,
+				prologo.PrologueClassic:        1,
 				prologo.PrologueNoFramePointer: 1,
 			},
 		},
 		{
-			name:      "unoptimized",
+			name:      "amd64/unoptimized",
+			goarch:    "amd64",
 			buildArgs: []string{"-gcflags=all=-N -l"},
 			minCounts: map[prologo.PrologueType]int{
 				prologo.PrologueClassic: 1,
+			},
+		},
+		{
+			name:      "arm64/optimized",
+			goarch:    "arm64",
+			buildArgs: nil,
+			minCounts: map[prologo.PrologueType]int{
+				prologo.PrologueSTRLRPreIndex: 1,
+			},
+		},
+		{
+			name:      "arm64/unoptimized",
+			goarch:    "arm64",
+			buildArgs: []string{"-gcflags=all=-N -l"},
+			minCounts: map[prologo.PrologueType]int{
+				prologo.PrologueSTRLRPreIndex: 1,
 			},
 		},
 	}
@@ -124,7 +261,7 @@ func TestDetectProloguesFromELF(t *testing.T) {
 			args = append(args, demoAppSource)
 
 			cmd := exec.Command("go", args...)
-			cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+			cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOARCH="+tt.goarch)
 			if out, err := cmd.CombinedOutput(); err != nil {
 				t.Fatalf("failed to compile demo-app: %v\n%s", err, out)
 			}

--- a/example_test.go
+++ b/example_test.go
@@ -11,7 +11,7 @@ import (
 func ExampleDetectPrologues() {
 	// x86-64 machine code: nop; push rbp; mov rbp, rsp
 	code := []byte{0x90, 0x55, 0x48, 0x89, 0xe5}
-	prologues, err := prologo.DetectPrologues(code, 0x1000)
+	prologues, err := prologo.DetectPrologues(code, 0x1000, prologo.ArchAMD64)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/prologue.go
+++ b/prologue.go
@@ -1,14 +1,31 @@
 package prologo
 
+// Arch represents a CPU architecture.
+type Arch string
+
+// Supported architectures.
+const (
+	ArchAMD64 Arch = "amd64"
+	ArchARM64 Arch = "arm64"
+)
+
 // PrologueType represents the type of function prologue.
 type PrologueType string
 
-// Recognized function prologue patterns.
+// Recognized x86_64 function prologue patterns.
 const (
-	PrologueClassic   PrologueType = "classic"
+	PrologueClassic        PrologueType = "classic"
 	PrologueNoFramePointer PrologueType = "no-frame-pointer"
-	ProloguePushOnly  PrologueType = "push-only"
-	PrologueLEABased  PrologueType = "lea-based"
+	ProloguePushOnly       PrologueType = "push-only"
+	PrologueLEABased       PrologueType = "lea-based"
+)
+
+// Recognized ARM64 function prologue patterns.
+const (
+	PrologueSTPFramePair PrologueType = "stp-frame-pair"
+	PrologueSTRLRPreIndex PrologueType = "str-lr-preindex"
+	PrologueSubSP        PrologueType = "sub-sp"
+	PrologueSTPOnly      PrologueType = "stp-only"
 )
 
 // Prologue represents a detected function prologue.


### PR DESCRIPTION
This commit considers both GCC/clang and Go compiler prologue conventions.