### PR TITLE
test: gcc/clang function prologues

### DIFF
--- a/testdata/demo-app.c
+++ b/testdata/demo-app.c
@@ -1,0 +1,5 @@
+__attribute__((noinline)) int add(int a, int b) { return a + b; }
+__attribute__((noinline)) int multiply(int a, int b) { return a * b; }
+__attribute__((noinline)) int subtract(int a, int b) { return a - b; }
+__attribute__((noinline)) int divide(int a, int b) { return b ? a / b : 0; }
+int main() { return add(1, multiply(2, subtract(3, divide(4, 2)))); }


### PR DESCRIPTION
GCC and Clang has different conventions over prologues compared to the Go compiler. This commit adds integration tests by attempting to compile a C sample application with both gcc and clang, if available. They are skipped if not available in the machine that runs the tests.