### PR TITLE
feat: filter loop-head aligned entries via backward-branch targets

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -106,13 +106,27 @@ func DetectFunctions(code []byte, baseAddr uint64, arch Arch) ([]FunctionCandida
 		}
 	}
 
+	// Build a set of backward-branch targets (loop heads). A loop head is an
+	// address targeted by a backward unconditional branch (JMP on AMD64, B on
+	// ARM64) where target < source - these are loop back-edges. GCC aligns
+	// loop heads to 16-byte boundaries with NOP fill at -O2, producing the
+	// same ret+NOP+aligned pattern as a function separator. Excluding them
+	// before emitting aligned-entry candidates removes the main FP source.
+	loopHeads := make(map[uint64]struct{})
+	for _, edge := range edges {
+		if edge.Type == CallSiteJump && edge.TargetAddr < edge.SourceAddr {
+			loopHeads[edge.TargetAddr] = struct{}{}
+		}
+	}
+
 	// Add alignment-based candidates for functions that have no prologue and
 	// no call-site signal (e.g. pure-leaf functions with external linkage
 	// that were never called due to inlining or compile-time evaluation).
 	//
 	// These receive ConfidenceLow because the pattern (ret + NOP padding →
 	// 16-byte aligned address) is reliable for function separators but can
-	// also match intra-function alignment at loop heads.
+	// also match intra-function alignment at loop heads. Loop heads are
+	// excluded above via the backward-branch filter.
 	var alignedEntries []uint64
 	switch arch {
 	case ArchAMD64:
@@ -121,6 +135,9 @@ func DetectFunctions(code []byte, baseAddr uint64, arch Arch) ([]FunctionCandida
 		alignedEntries = detectAlignedEntriesARM64(code, baseAddr)
 	}
 	for _, addr := range alignedEntries {
+		if _, isLoopHead := loopHeads[addr]; isLoopHead {
+			continue // backward-branch target: loop head, not a function entry
+		}
 		if _, exists := candidates[addr]; !exists {
 			candidates[addr] = &FunctionCandidate{
 				Address:       addr,


### PR DESCRIPTION
With `-O2`, GCC aligns loop heads to 16-byte boundaries using NOP fill, which produces the same `ret + NOP + aligned address` pattern as a function separator. The aligned-entry detector fires on these, contributing false positives.

This adds a post-filter to `DetectFunctions`: before emitting aligned-entry candidates, build a set of backward-branch targets from the already-computed call-site edges. Any unconditional JMP/B where `target < source` is a loop back-edge, and its target is a loop head - skip it.

No extra scan pass is needed. The edges are already produced by `DetectCallSites`, which `DetectFunctions` calls regardless.

Tracks: #18