### PR TITLE
feat: filter out candidates inside PLT sections

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -166,14 +166,34 @@ func DetectFunctionsFromELF(r io.ReaderAt) ([]FunctionCandidate, error) {
 		return nil, fmt.Errorf("failed to read .text section: %w", err)
 	}
 
+	var arch Arch
 	switch f.Machine {
 	case elf.EM_X86_64:
-		return DetectFunctions(code, textSec.Addr, ArchAMD64)
+		arch = ArchAMD64
 	case elf.EM_AARCH64:
-		return DetectFunctions(code, textSec.Addr, ArchARM64)
+		arch = ArchARM64
 	default:
 		return nil, fmt.Errorf("unsupported ELF machine: %s", f.Machine)
 	}
+
+	candidates, err := DetectFunctions(code, textSec.Addr, arch)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove candidates that land inside linker-generated PLT sections.
+	// The call-site scanner records CALL/JMP targets regardless of which
+	// section they resolve to; PLT stubs are not real function entries.
+	pltNames := []string{".plt", ".plt.got", ".plt.sec", ".iplt"}
+	var pltRanges [][2]uint64
+	for _, name := range pltNames {
+		if sec := f.Section(name); sec != nil {
+			pltRanges = append(pltRanges, [2]uint64{sec.Addr, sec.Addr + sec.Size})
+		}
+	}
+	candidates = filterCandidatesInRanges(candidates, pltRanges)
+
+	return candidates, nil
 }
 
 // DetectPrologues analyzes raw machine code bytes and returns detected function

--- a/filter.go
+++ b/filter.go
@@ -2,6 +2,32 @@ package resurgo
 
 import "slices"
 
+// filterCandidatesInRanges removes candidates whose addresses fall within any
+// of the given address ranges. Each range is a [lo, hi) pair.
+//
+// Used to discard candidates that land inside linker-generated sections (e.g.
+// PLT stubs) that the call-site scanner can detect as CALL/JMP targets even
+// though they are not real function entries in the binary under analysis.
+func filterCandidatesInRanges(candidates []FunctionCandidate, ranges [][2]uint64) []FunctionCandidate {
+	if len(ranges) == 0 {
+		return candidates
+	}
+	result := candidates[:0]
+	for _, c := range candidates {
+		inRange := false
+		for _, r := range ranges {
+			if c.Address >= r[0] && c.Address < r[1] {
+				inRange = true
+				break
+			}
+		}
+		if !inRange {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
 // filterJumpTargetsByAnchorRange removes DetectionJumpTarget candidates that
 // are intra-function branch targets from the candidates map.
 //


### PR DESCRIPTION
The call-site scanner records every CALL/JMP target address regardless
of which ELF section it resolves to. PLT stubs (.plt, .plt.got,
.plt.sec, .iplt) are linker-generated trampolines, not real function
entries, so they surface as false positives in the candidate list.

## What

`DetectFunctionsFromELF` now reads the address range of each PLT-related
section from the ELF header and discards any candidate whose address
falls within those ranges.

`filterCandidatesInRanges` in `filter.go` implements the check. It is
decoupled from the ELF layer and operates on plain `[lo, hi)` ranges,
so it can be reused for other section-based filters in the future.

## Results

vs main (gcc 14.2.0, all TPs preserved on both architectures):

    unoptimized AMD64:  FP 1.00x -> 0.67x  (4 FPs remain)
    optimized AMD64:    FP 1.40x -> 1.00x  (5 FPs remain)
    optimized ARM64:    FP 3.40x -> 2.40x  (12 FPs remain)

## Tests

All e2e tests pass. No threshold changes required - the existing
assertions are satisfied by the improved numbers.

Tracks: #18