### PR TITLE
ci: run e2e tests in a pinned Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version-file: go.mod
-      - name: Install C toolchain
+      - name: Build e2e image
+        run: docker build -t resurgo-e2e -f e2e/Dockerfile .
+      - name: Run e2e tests
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc binutils
-      - name: Install ARM64 cross-compiler
-        run: sudo apt-get install -y gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
-      - run: go test -v -tags e2e ./e2e/...
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            resurgo-e2e \
+            go test -v -tags e2e ./e2e/...

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: test test-e2e
+
+test:
+	go test -v -race ./...
+
+test-e2e:
+	docker build -t resurgo-e2e -f e2e/Dockerfile .
+	docker run --rm \
+		-v $(CURDIR):/workspace \
+		-w /workspace \
+		resurgo-e2e \
+		go test -v -tags e2e ./e2e/...

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.25
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    binutils \
+    gcc-aarch64-linux-gnu \
+    binutils-aarch64-linux-gnu \
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The e2e tests compile C test binaries at runtime using whatever gcc is
available on the host. Different gcc versions produce different binary
layouts and function prologues, so results diverge between local runs
and CI (Ubuntu 24.04 vs Debian-based Docker images).

## What

`e2e/Dockerfile` based on `golang:1.25` (Debian Bookworm), with gcc and
the `aarch64-linux-gnu` cross-compiler pinned to the same package
versions as the base image.

The `test-e2e` CI job now builds this image and runs the tests inside
it instead of installing packages on the bare runner. A new `Makefile`
exposes the same `make test-e2e` command locally, so the compiler and
libc versions are identical in CI and on developer machines.

## Why

`main` was being reported as NOT DETECTED in CI because Ubuntu 24.04's
gcc generates a different prologue than Debian's gcc. With a pinned
image both environments see the same binary, same addresses, same
results.

## Usage

```
make test-e2e
