### PR TITLE
fix(e2e): add ARM64 sysroot headers to Dockerfile

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -5,4 +5,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     binutils \
     gcc-aarch64-linux-gnu \
     binutils-aarch64-linux-gnu \
+    libc6-dev-arm64-cross \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
\`gcc-aarch64-linux-gnu\` ships the cross-compiler but not the ARM64
libc headers. The ARM64 e2e test was failing with:

\`\`\`
fatal error: bits/libc-header-start.h: No such file or directory
\`\`\`

Adding \`libc6-dev-arm64-cross\` to the Dockerfile provides the
missing sysroot headers and makes \`TestDetectFunctionsFromELF_StrippedC_Optimized_ARM64\`
compile cleanly.

Verified by building the image and running the full e2e suite locally:

\`\`\`
--- PASS: TestDetectFunctionsFromELF_StrippedC_Unoptimized (0.04s)
--- PASS: TestDetectFunctionsFromELF_StrippedC_Optimized (0.08s)
--- PASS: TestDetectFunctionsFromELF_StrippedC_Optimized_ARM64 (0.09s)
\`\`\`