### PR TITLE
test: add filter tests and tighten FP thresholds

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -236,9 +236,10 @@ func TestDetectFunctionsFromELF_StrippedC_Unoptimized(t *testing.T) {
 			stats.tpRate(), stats.truePositives, stats.total, stats.missed)
 	}
 
-	// FP multiplier should stay below 2x - only CRT noise expected.
-	if stats.fpMultiplier() >= 2.0 {
-		t.Errorf("false positive multiplier %.2fx >= 2.00x: detector is too noisy",
+	// FP multiplier should stay below 1x - PLT stubs are filtered,
+	// only residual CRT noise expected.
+	if stats.fpMultiplier() >= 1.0 {
+		t.Errorf("false positive multiplier %.2fx >= 1.00x: detector is too noisy",
 			stats.fpMultiplier())
 	}
 
@@ -283,27 +284,27 @@ func TestDetectFunctionsFromELF_StrippedC_Optimized(t *testing.T) {
 		t.Errorf("fib(0x%x): confidence=%s, want high", va, c.Confidence)
 	}
 
-	// Document the limitation explicitly: true positive rate must be below
-	// 100% and false positive multiplier must be above 1x. If either
-	// assertion flips, resurgo has improved (update the test) or regressed.
+	// Document the known limitation: TP rate may be below 100% due to
+	// inlining. If it flips to 100%, issue #13 may be resolved.
 	if stats.tpRate() == 100 {
 		t.Logf("NOTICE: true positive rate is now 100%% - issue #13 may be resolved; " +
 			"consider promoting this test to a full recall assertion")
 	}
-	if stats.fpMultiplier() <= 1.0 {
-		t.Logf("NOTICE: false positive multiplier dropped to %.2fx - noise reduced",
-			stats.fpMultiplier())
-	}
 
-	// Snapshot bounds: TP rate expected around 40% (2/5), FP multiplier
-	// expected above 1x. These are soft checks that print context without
-	// failing the build - they exist so any significant shift is visible in
-	// CI output.
-	t.Logf("snapshot: tp_rate=%.0f%% missed=%.0f%% fp_multiplier=%.2fx",
-		stats.tpRate(), stats.missedRate(), stats.fpMultiplier())
+	// At least one function must be found.
 	if stats.truePositives == 0 {
 		t.Errorf("true positives: 0/%d - detector found nothing; regression?", stats.total)
 	}
+
+	// FP multiplier must stay below 1.5x. PLT stubs are now filtered;
+	// only CRT noise remains (~1.0x baseline with gcc 14.2.0).
+	if stats.fpMultiplier() >= 1.5 {
+		t.Errorf("false positive multiplier %.2fx >= 1.50x: detector is too noisy",
+			stats.fpMultiplier())
+	}
+
+	t.Logf("snapshot: tp_rate=%.0f%% missed=%.0f%% fp_multiplier=%.2fx",
+		stats.tpRate(), stats.missedRate(), stats.fpMultiplier())
 }
 
 // TestDetectFunctionsFromELF_StrippedC_Optimized_ARM64 validates boundary
@@ -345,6 +346,14 @@ func TestDetectFunctionsFromELF_StrippedC_Optimized_ARM64(t *testing.T) {
 	if stats.truePositives < 4 {
 		t.Errorf("true positives: %d/%d - regression? expected at least 4; missed: %v",
 			stats.truePositives, stats.total, stats.missed)
+	}
+
+	// FP multiplier must stay below 3x. PLT stubs are filtered; residual
+	// FPs are CRT functions and intra-CRT jump targets (~2.4x baseline
+	// with gcc 14.2.0 aarch64-linux-gnu).
+	if stats.fpMultiplier() >= 3.0 {
+		t.Errorf("false positive multiplier %.2fx >= 3.00x: detector is too noisy",
+			stats.fpMultiplier())
 	}
 
 	t.Logf("snapshot: tp_rate=%.0f%% missed=%.0f%% fp_multiplier=%.2fx",

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,100 @@
+package resurgo
+
+import (
+	"testing"
+)
+
+func TestFilterCandidatesInRanges(t *testing.T) {
+	cands := func(addrs ...uint64) []FunctionCandidate {
+		out := make([]FunctionCandidate, len(addrs))
+		for i, a := range addrs {
+			out[i] = FunctionCandidate{Address: a}
+		}
+		return out
+	}
+
+	addrs := func(cs []FunctionCandidate) []uint64 {
+		out := make([]uint64, len(cs))
+		for i, c := range cs {
+			out[i] = c.Address
+		}
+		return out
+	}
+
+	tests := []struct {
+		name   string
+		input  []FunctionCandidate
+		ranges [][2]uint64
+		want   []uint64
+	}{
+		{
+			name:   "no ranges keeps all",
+			input:  cands(0x100, 0x200, 0x300),
+			ranges: nil,
+			want:   []uint64{0x100, 0x200, 0x300},
+		},
+		{
+			name:   "empty input",
+			input:  cands(),
+			ranges: [][2]uint64{{0x100, 0x200}},
+			want:   []uint64{},
+		},
+		{
+			name:  "removes candidate inside range",
+			input: cands(0x100, 0x150, 0x200),
+			ranges: [][2]uint64{
+				{0x140, 0x160},
+			},
+			want: []uint64{0x100, 0x200},
+		},
+		{
+			name:  "lo boundary included hi boundary excluded",
+			input: cands(0x100, 0x140, 0x160, 0x200),
+			ranges: [][2]uint64{
+				{0x140, 0x160},
+			},
+			want: []uint64{0x100, 0x160, 0x200},
+		},
+		{
+			name:  "multiple ranges",
+			input: cands(0x100, 0x200, 0x300, 0x400, 0x500),
+			ranges: [][2]uint64{
+				{0x180, 0x220},
+				{0x380, 0x420},
+			},
+			want: []uint64{0x100, 0x300, 0x500},
+		},
+		{
+			name:  "all candidates removed",
+			input: cands(0x100, 0x110, 0x120),
+			ranges: [][2]uint64{
+				{0x100, 0x130},
+			},
+			want: []uint64{},
+		},
+		{
+			name:  "no candidates in range",
+			input: cands(0x100, 0x200),
+			ranges: [][2]uint64{
+				{0x300, 0x400},
+			},
+			want: []uint64{0x100, 0x200},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterCandidatesInRanges(tt.input, tt.ranges)
+			gotAddrs := addrs(got)
+			if len(gotAddrs) != len(tt.want) {
+				t.Fatalf("len=%d want=%d: got %v want %v",
+					len(gotAddrs), len(tt.want), gotAddrs, tt.want)
+			}
+			for i := range tt.want {
+				if gotAddrs[i] != tt.want[i] {
+					t.Errorf("[%d] got 0x%x want 0x%x", i, gotAddrs[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to the PLT section filter merged in #22.

The PLT filter brought FP multipliers down significantly, but the e2e
assertions were still the old soft snapshots. This PR enforces the
improvement as hard test failures and adds unit test coverage for the
new filter function.

## Unit tests

\`filter_test.go\` covers \`filterCandidatesInRanges\` with 7 table-driven
cases: no ranges (keep all), empty input, single range removal,
boundary semantics (lo inclusive, hi exclusive), multiple ranges,
full removal, and no-overlap passthrough.

## E2e threshold tightening

| test | before | after | baseline |
|------|--------|-------|----------|
| unoptimized AMD64 | \`< 2.0x\` | \`< 1.0x\` | 0.67x |
| optimized AMD64 | soft log | \`< 1.5x\` | 1.00x |
| optimized ARM64 | soft log | \`< 3.0x\` | 2.40x |

Residual FPs on ARM64 (2.40x) are CRT boilerplate and intra-CRT
jump targets inside \`.text\` - not addressable by section range
filtering.