### PR TITLE
docs: update README for v0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It works with raw bytes from any binary format as well as parsing ELF files.
 - **Prologue-Based Detection**: Recognizes common function entry patterns by instruction analysis
 - **Call-Site Analysis**: Identifies functions through CALL and JMP target extraction
 - **Boundary Analysis**: Recovers leaf and never-called functions via compiler alignment gaps
+- **False Positive Filtering**: Discards intra-function jump targets (anchor-range filter) and linker-generated PLT stubs (section-range filter) from the candidate list
 - **Format-Agnostic Core**: Works on raw machine code bytes from any binary format
 - **ELF Convenience Wrapper**: Built-in support for parsing ELF executables
 - **Pattern Classification**: Labels detected functions by detection type and confidence
@@ -248,7 +249,8 @@ func DetectCallSitesFromELF(r io.ReaderAt) ([]CallSiteEdge, error)
 // Functions detected by both methods receive the highest confidence rating.
 func DetectFunctions(code []byte, baseAddr uint64, arch Arch) ([]FunctionCandidate, error)
 
-// Convenience wrapper  - parses ELF from the reader, extracts .text, calls DetectFunctions.
+// Convenience wrapper  - parses ELF from the reader, extracts .text, calls DetectFunctions,
+// then applies FP filters (PLT section ranges, intra-function jump targets).
 func DetectFunctionsFromELF(r io.ReaderAt) ([]FunctionCandidate, error)
 ```
 
@@ -387,6 +389,11 @@ type FunctionCandidate struct {
             └───────┬───────┘
                     ▼
             ┌───────────────┐
+            │  FP Filters   │ ← Anchor-range (intra-func JMPs)
+            │               │   PLT section ranges
+            └───────┬───────┘
+                    ▼
+            ┌───────────────┐
             │[]FunctionCand │
             │    idate      │
             └───────────────┘
@@ -395,12 +402,12 @@ type FunctionCandidate struct {
 ## Limitations
 
 - **No Symbol Information**: Works on stripped binaries but reports addresses only
-- **Heuristic-Based**: May have false positives in data sections or inline data
+- **Heuristic-Based**: PLT stubs and intra-function jump targets are filtered, but intra-function branches inside CRT code may still produce false positives when they land on aligned addresses with no surrounding anchor functions
 - **Linear Disassembly**: Doesn't handle indirect jumps or computed addresses
 
 ## Dependencies
 
-- **Go 1.21+**
+- **Go 1.25.7+**
 - [`golang.org/x/arch`](https://pkg.go.dev/golang.org/x/arch) - x86 and ARM64 disassembler
 - `debug/elf` (standard library) - ELF parser
 


### PR DESCRIPTION
Four updates to bring the README in sync with v0.3.2.

**Features**: new False Positive Filtering bullet covering the
anchor-range filter (intra-function JMP targets) and the PLT
section-range filter.

**Architecture diagram**: add FP Filters step between
\`DetectFunctions\` and the output slice; previously the diagram
skipped it entirely.

**API comment**: \`DetectFunctionsFromELF\` doc now mentions that FP
filters are applied after \`DetectFunctions\`.

**Limitations**: replace the generic "may have false positives" note
with a precise description of what is filtered and what remains
(intra-CRT branches on aligned addresses without anchor functions).

**Dependencies**: Go requirement corrected from 1.21+ to 1.25.7+.