### PR TITLE
feat: CET-aware ENDBR64 filter for AMD64 aligned-based detection

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -29,6 +29,11 @@ const (
 	endbr32Byte3 = byte(0xFB)
 )
 
+// endbr64Bytes is the 4-byte encoding of the ENDBR64 instruction as a
+// fixed-size array for direct comparison. Built from the individual byte
+// constants so the encoding is defined in one place.
+var endbr64Bytes = [4]byte{endbr64Byte0, endbr64Byte1, endbr64Byte2, endbr64Byte3}
+
 // Confidence represents the reliability level of a detected function candidate.
 type Confidence string
 

--- a/filter.go
+++ b/filter.go
@@ -14,6 +14,7 @@ type CandidateFilter func([]FunctionCandidate, *elf.File) ([]FunctionCandidate, 
 // registers its filter here; order matters.
 var elfFilters = []CandidateFilter{
 	pltFilter,
+	cetFilter,
 	ehFrameFilter,
 }
 
@@ -26,6 +27,76 @@ func pltFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error)
 		}
 	}
 	return filterCandidatesInRanges(cs, pltRanges), nil
+}
+
+// cetFilter applies the CET-aware ENDBR64 filter on AMD64 ELF binaries.
+// Non-AMD64 binaries are returned unchanged. The filter must run before
+// ehFrameFilter so that any aligned-entry candidate it drops can be recovered
+// as DetectionCFI when its address appears in an FDE record (e.g. _start has
+// no ENDBR64 but does have an FDE entry).
+func cetFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error) {
+	if f.Machine != elf.EM_X86_64 {
+		return cs, nil
+	}
+	textSec := f.Section(".text")
+	if textSec == nil {
+		return cs, nil
+	}
+	textBytes, err := textSec.Data()
+	if err != nil {
+		return nil, err
+	}
+	return filterAlignedEntriesCETAMD64(cs, textBytes, textSec.Addr), nil
+}
+
+// filterAlignedEntriesCETAMD64 drops aligned-entry candidates lacking ENDBR64
+// on CET-enabled AMD64 binaries. On CET binaries every indirect-branch-target
+// function entry carries ENDBR64; an aligned address inside a function body
+// (reached by a jump or NOP padding) never does, making it a reliable
+// discriminator for aligned-entry false positives.
+//
+// CET is detected when >= 5 aligned-entry candidates carry ENDBR64; this
+// avoids false triggering on non-CET binaries that may have a few incidental
+// ENDBR64 hits from CRT helpers. Non-CET binaries are returned unchanged.
+// Only DetectionAlignedEntry candidates are affected.
+func filterAlignedEntriesCETAMD64(candidates []FunctionCandidate, textBytes []byte, textVA uint64) []FunctionCandidate {
+	hasENDBR64 := func(va uint64) bool {
+		if va < textVA {
+			return false
+		}
+		off := va - textVA
+		if off+4 > uint64(len(textBytes)) {
+			return false
+		}
+		return [4]byte(textBytes[off:off+4]) == endbr64Bytes
+	}
+
+	// Threshold of 5: non-CET binaries can have up to ~4 incidental ENDBR64
+	// hits from CRT helpers; 5 or more reliably indicates a CET binary.
+	const cetMinHits = 5
+	cetHits := 0
+	for i := range candidates {
+		if candidates[i].DetectionType == DetectionAlignedEntry && hasENDBR64(candidates[i].Address) {
+			cetHits++
+			if cetHits >= cetMinHits {
+				break
+			}
+		}
+	}
+	if cetHits < cetMinHits {
+		return candidates
+	}
+
+	// CET binary: keep only aligned-entry candidates that have ENDBR64.
+	// All other detection types are kept unconditionally.
+	result := candidates[:0]
+	for _, c := range candidates {
+		if c.DetectionType == DetectionAlignedEntry && !hasENDBR64(c.Address) {
+			continue
+		}
+		result = append(result, c)
+	}
+	return result
 }
 
 // filterCandidatesInRanges removes candidates whose addresses fall within any

--- a/filter_test.go
+++ b/filter_test.go
@@ -4,6 +4,86 @@ import (
 	"testing"
 )
 
+func TestFilterAlignedEntriesCETAMD64(t *testing.T) {
+	const textVA = uint64(0x1000)
+
+	endbr64 := []byte{0xf3, 0x0f, 0x1e, 0xfa}
+
+	addrs := func(cs []FunctionCandidate) []uint64 {
+		out := make([]uint64, len(cs))
+		for i, c := range cs {
+			out[i] = c.Address
+		}
+		return out
+	}
+
+	// 4 ENDBR64 hits at 0x00–0x30; zeroes at 0x40 and 0x50.
+	text1 := make([]byte, 0x60)
+	for _, off := range []int{0x00, 0x10, 0x20, 0x30} {
+		copy(text1[off:], endbr64)
+	}
+
+	// 5 ENDBR64 hits at 0x00–0x40 (triggers CET) and one more at 0x80;
+	// zeroes at 0x50, 0x60, 0x70.
+	text2 := make([]byte, 0x90)
+	for _, off := range []int{0x00, 0x10, 0x20, 0x30, 0x40, 0x80} {
+		copy(text2[off:], endbr64)
+	}
+
+	tests := []struct {
+		name      string
+		text      []byte
+		input     []FunctionCandidate
+		wantAddrs []uint64
+	}{
+		{
+			name: "non-CET binary returns all candidates unchanged",
+			text: text1,
+			input: []FunctionCandidate{
+				{Address: 0x1000, DetectionType: DetectionAlignedEntry},
+				{Address: 0x1010, DetectionType: DetectionAlignedEntry},
+				{Address: 0x1020, DetectionType: DetectionAlignedEntry},
+				{Address: 0x1030, DetectionType: DetectionAlignedEntry}, // 4 ENDBR64: below threshold
+				{Address: 0x1040, DetectionType: DetectionAlignedEntry},
+				{Address: 0x1050, DetectionType: DetectionAlignedEntry},
+			},
+			wantAddrs: []uint64{0x1000, 0x1010, 0x1020, 0x1030, 0x1040, 0x1050},
+		},
+		{
+			name: "CET binary drops aligned-entry candidates without ENDBR64",
+			text: text2,
+			input: []FunctionCandidate{
+				{Address: 0x1000, DetectionType: DetectionAlignedEntry}, // ENDBR64 - kept
+				{Address: 0x1010, DetectionType: DetectionAlignedEntry}, // ENDBR64 - kept
+				{Address: 0x1020, DetectionType: DetectionAlignedEntry}, // ENDBR64 - kept
+				{Address: 0x1030, DetectionType: DetectionAlignedEntry}, // ENDBR64 - kept
+				{Address: 0x1040, DetectionType: DetectionAlignedEntry}, // ENDBR64 - kept (5th, triggers CET)
+				{Address: 0x1050, DetectionType: DetectionAlignedEntry}, // no ENDBR64 - dropped
+				{Address: 0x1060, DetectionType: DetectionAlignedEntry}, // no ENDBR64 - dropped
+				{Address: 0x1070, DetectionType: DetectionPrologueOnly}, // not AlignedEntry - kept
+				{Address: 0x1080, DetectionType: DetectionAlignedEntry}, // ENDBR64, after threshold - kept
+			},
+			wantAddrs: []uint64{0x1000, 0x1010, 0x1020, 0x1030, 0x1040, 0x1070, 0x1080},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterAlignedEntriesCETAMD64(tt.input, tt.text, textVA)
+			gotAddrs := addrs(got)
+			if len(gotAddrs) != len(tt.wantAddrs) {
+				t.Fatalf("len=%d want=%d: got %v want %v",
+					len(gotAddrs), len(tt.wantAddrs), gotAddrs, tt.wantAddrs)
+			}
+			for i := range tt.wantAddrs {
+				if gotAddrs[i] != tt.wantAddrs[i] {
+					t.Errorf("[%d] got 0x%x want 0x%x", i, gotAddrs[i], tt.wantAddrs[i])
+				}
+			}
+		})
+	}
+}
+
 func TestFilterCandidatesInRanges(t *testing.T) {
 	cands := func(addrs ...uint64) []FunctionCandidate {
 		out := make([]FunctionCandidate, len(addrs))


### PR DESCRIPTION
On AMD64 binaries compiled with `-fcf-protection=branch` (Intel CET/IBT), the compiler emits ENDBR64 at every function entry reachable via indirect branch. Intra-function aligned addresses - the main source of aligned-entry false positives - never carry ENDBR64.

`filterAlignedEntriesCETAMD64` exploits this: when >= 5 aligned-entry candidates start with ENDBR64 (the CET heuristic), all aligned-entry candidates without ENDBR64 are dropped. The threshold avoids false-triggering on non-CET binaries where a few CRT helpers carry ENDBR64 by coincidence.

The filter runs before the FDE whitelist so that any aligned-entry candidate it drops can be recovered by `ehFrameFilter` as `DetectionCFI` when its address appears in an FDE record (e.g. `_start`, which has no ENDBR64 but does have an FDE entry). On binaries with `.eh_frame`, FDE is the primary filter and CET has no measurable effect on FP count.

On a CET-enabled binary without `.eh_frame`, the filter reduces aligned-entry false positives significantly:
- before: 939 FPs (2.83x multiplier)
- after:  533 FPs (1.61x multiplier)

Non-CET binaries are unaffected.