### PR TITLE
docs: document fields on exported structs

### DIFF
--- a/callsite.go
+++ b/callsite.go
@@ -40,11 +40,18 @@ type AddressingMode string
 
 // CallSiteEdge represents a detected call site (call or jump to a function).
 type CallSiteEdge struct {
-	SourceAddr  uint64         `json:"source_addr"`
-	TargetAddr  uint64         `json:"target_addr"`
-	Type        CallSiteType   `json:"type"`
+	// SourceAddr is the virtual address of the call or jump instruction.
+	SourceAddr uint64 `json:"source_addr"`
+	// TargetAddr is the virtual address of the call or jump target.
+	TargetAddr uint64 `json:"target_addr"`
+	// Type indicates whether this edge was produced by a call or jump
+	// instruction.
+	Type CallSiteType `json:"type"`
+	// AddressMode describes how the target address is encoded in the
+	// instruction.
 	AddressMode AddressingMode `json:"address_mode"`
-	Confidence  Confidence     `json:"confidence"`
+	// Confidence is the reliability level of this edge.
+	Confidence Confidence `json:"confidence"`
 }
 
 // DetectCallSites analyzes raw machine code bytes and returns detected

--- a/detector.go
+++ b/detector.go
@@ -40,12 +40,21 @@ type DetectionType string
 // through one or more signals (prologue matching, call-site analysis,
 // boundary analysis, or CFI).
 type FunctionCandidate struct {
-	Address       uint64        `json:"address"`
+	// Address is the virtual address of the function entry point.
+	Address uint64 `json:"address"`
+	// DetectionType is the signal or combination of signals that produced
+	// this candidate.
 	DetectionType DetectionType `json:"detection_type"`
-	PrologueType  PrologueType  `json:"prologue_type,omitempty"`
-	CalledFrom    []uint64      `json:"called_from,omitempty"`
-	JumpedFrom    []uint64      `json:"jumped_from,omitempty"`
-	Confidence    Confidence    `json:"confidence"`
+	// PrologueType is the matched prologue pattern, if any.
+	PrologueType PrologueType `json:"prologue_type,omitempty"`
+	// CalledFrom holds the virtual addresses of instructions that call this
+	// candidate directly.
+	CalledFrom []uint64 `json:"called_from,omitempty"`
+	// JumpedFrom holds the virtual addresses of instructions that jump to
+	// this candidate.
+	JumpedFrom []uint64 `json:"jumped_from,omitempty"`
+	// Confidence is the reliability level of this candidate.
+	Confidence Confidence `json:"confidence"`
 }
 
 // isENDBR reports whether the 4 bytes at code[i:i+4] encode an ENDBR64

--- a/prologue.go
+++ b/prologue.go
@@ -30,7 +30,11 @@ type PrologueType string
 
 // Prologue represents a detected function prologue.
 type Prologue struct {
-	Address      uint64       `json:"address"`
-	Type         PrologueType `json:"type"`
-	Instructions string       `json:"instructions"`
+	// Address is the virtual address of the detected prologue.
+	Address uint64 `json:"address"`
+	// Type is the matched prologue pattern.
+	Type PrologueType `json:"type"`
+	// Instructions is a human-readable representation of the matched
+	// prologue instructions.
+	Instructions string `json:"instructions"`
 }


### PR DESCRIPTION
Add godoc comments to all fields of `FunctionCandidate`, `Prologue`, and `CallSiteEdge`. All other exported symbols are already documented.