### PR TITLE
refactor: make filters composable via options

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -192,7 +192,17 @@ func DetectFunctions(code []byte, baseAddr uint64, arch Arch) ([]FunctionCandida
 // discard disassembly candidates that are not confirmed by the compiler, and
 // any function entries visible only in .eh_frame are added to the result.
 // The architecture is inferred from the ELF header.
-func DetectFunctionsFromELF(r io.ReaderAt) ([]FunctionCandidate, error) {
+//
+// By default the full filter pipeline (PLTFilter, CETFilter, EhFrameFilter)
+// is applied. Use WithFilters to override it.
+func DetectFunctionsFromELF(r io.ReaderAt, opts ...Option) ([]FunctionCandidate, error) {
+	o := &options{
+		filters: []CandidateFilter{PLTFilter, CETFilter, EhFrameFilter},
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
 	f, err := elf.NewFile(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse ELF file: %w", err)
@@ -224,7 +234,7 @@ func DetectFunctionsFromELF(r io.ReaderAt) ([]FunctionCandidate, error) {
 		return nil, err
 	}
 
-	for _, filter := range elfFilters {
+	for _, filter := range o.filters {
 		candidates, err = filter(candidates, f)
 		if err != nil {
 			return nil, err

--- a/dwarf.go
+++ b/dwarf.go
@@ -37,9 +37,9 @@ type cieInfo struct {
 	fdeEncoding byte // DW_EH_PE_* byte from 'R' augmentation datum
 }
 
-// ehFrameFilter parses .eh_frame and applies the FDE whitelist to the
+// EhFrameFilter parses .eh_frame and applies the FDE whitelist to the
 // candidate slice. See applyEhFrame for the merge logic.
-func ehFrameFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error) {
+func EhFrameFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error) {
 	fdeVAs, err := parseEhFrameEntries(f)
 	if err != nil {
 		return nil, fmt.Errorf("parse .eh_frame: %w", err)

--- a/filter.go
+++ b/filter.go
@@ -9,17 +9,23 @@ import (
 // Each filter reads only what it needs from f and returns the updated slice.
 type CandidateFilter func([]FunctionCandidate, *elf.File) ([]FunctionCandidate, error)
 
-// elfFilters is the ordered list of ELF-specific candidate filters applied by
-// DetectFunctionsFromELF after the disassembly pipeline. Each strategy
-// registers its filter here; order matters.
-var elfFilters = []CandidateFilter{
-	pltFilter,
-	cetFilter,
-	ehFrameFilter,
+// Option configures the behaviour of DetectFunctionsFromELF.
+type Option func(*options)
+
+type options struct {
+	filters []CandidateFilter
 }
 
-// pltFilter removes candidates that land inside linker-generated PLT sections.
-func pltFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error) {
+// WithFilters sets the filter pipeline applied after disassembly. Filters run
+// in the order provided. Pass no arguments to disable all filters.
+func WithFilters(filters ...CandidateFilter) Option {
+	return func(o *options) {
+		o.filters = filters
+	}
+}
+
+// PLTFilter removes candidates that land inside linker-generated PLT sections.
+func PLTFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error) {
 	var pltRanges [][2]uint64
 	for _, name := range []string{".plt", ".plt.got", ".plt.sec", ".iplt"} {
 		if sec := f.Section(name); sec != nil {
@@ -29,12 +35,12 @@ func pltFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error)
 	return filterCandidatesInRanges(cs, pltRanges), nil
 }
 
-// cetFilter applies the CET-aware ENDBR64 filter on AMD64 ELF binaries.
+// CETFilter applies the CET-aware ENDBR64 filter on AMD64 ELF binaries.
 // Non-AMD64 binaries are returned unchanged. The filter must run before
-// ehFrameFilter so that any aligned-entry candidate it drops can be recovered
+// EhFrameFilter so that any aligned-entry candidate it drops can be recovered
 // as DetectionCFI when its address appears in an FDE record (e.g. _start has
 // no ENDBR64 but does have an FDE entry).
-func cetFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error) {
+func CETFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error) {
 	if f.Machine != elf.EM_X86_64 {
 		return cs, nil
 	}


### PR DESCRIPTION
PLTFilter, CETFilter, and EhFrameFilter are now exported so callers can reference them directly. DetectFunctionsFromELF accepts variadic Option arguments; WithFilters replaces the active filter pipeline.

Default behavior is unchanged: all three filters run in order when no options are passed. Callers can pass WithFilters() to disable all filters, or WithFilters(PLTFilter, CETFilter) to drop the FDE whitelist, enabling isolation of individual pipeline stages in tests.