### PR TITLE
docs: document filter options API

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,18 @@ func DetectFunctions(code []byte, baseAddr uint64, arch Arch) ([]FunctionCandida
 // DetectFunctionsFromELF parses an ELF binary, runs all detection signals,
 // applies false-positive filters (PLT ranges, intra-function jump targets),
 // and, when .eh_frame is present, uses CFI FDE entries as a whitelist.
-// Architecture is inferred from the ELF header.
-func DetectFunctionsFromELF(r io.ReaderAt) ([]FunctionCandidate, error)
+// Architecture is inferred from the ELF header. opts may include WithFilters
+// to replace the default filter pipeline.
+func DetectFunctionsFromELF(r io.ReaderAt, opts ...Option) ([]FunctionCandidate, error)
+
+// WithFilters replaces the active filter pipeline. filters run in the order
+// provided. Pass no arguments to disable all filters.
+func WithFilters(filters ...CandidateFilter) Option
+
+// Built-in filters, enabled by default in the order listed:
+var PLTFilter     CandidateFilter  // removes PLT-section candidates
+var CETFilter     CandidateFilter  // drops non-ENDBR64 aligned entries on CET AMD64 binaries
+var EhFrameFilter CandidateFilter  // applies .eh_frame FDE whitelist
 
 // DetectPrologues scans raw machine code bytes for architecture-specific
 // function prologue patterns. Works on any binary format.
@@ -128,7 +138,7 @@ const (
     DetectionPrologueOnly DetectionType = "prologue-only"
     DetectionCallTarget   DetectionType = "call-target"
     DetectionJumpTarget   DetectionType = "jump-target"
-    DetectionBoth         DetectionType = "both"
+    DetectionPrologueCallSite DetectionType = "prologue-callsite"
     DetectionAlignedEntry DetectionType = "aligned-entry"
     DetectionCFI          DetectionType = "cfi"
 )

--- a/detector.go
+++ b/detector.go
@@ -194,7 +194,7 @@ func DetectFunctions(code []byte, baseAddr uint64, arch Arch) ([]FunctionCandida
 // The architecture is inferred from the ELF header.
 //
 // By default the full filter pipeline (PLTFilter, CETFilter, EhFrameFilter)
-// is applied. Use WithFilters to override it.
+// is applied. opts may include WithFilters to replace the default pipeline.
 func DetectFunctionsFromELF(r io.ReaderAt, opts ...Option) ([]FunctionCandidate, error) {
 	o := &options{
 		filters: []CandidateFilter{PLTFilter, CETFilter, EhFrameFilter},

--- a/dwarf.go
+++ b/dwarf.go
@@ -37,8 +37,8 @@ type cieInfo struct {
 	fdeEncoding byte // DW_EH_PE_* byte from 'R' augmentation datum
 }
 
-// EhFrameFilter parses .eh_frame and applies the FDE whitelist to the
-// candidate slice. See applyEhFrame for the merge logic.
+// EhFrameFilter parses .eh_frame from f and applies the FDE whitelist to cs.
+// See applyEhFrame for the merge logic.
 func EhFrameFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error) {
 	fdeVAs, err := parseEhFrameEntries(f)
 	if err != nil {

--- a/filter.go
+++ b/filter.go
@@ -16,7 +16,7 @@ type options struct {
 	filters []CandidateFilter
 }
 
-// WithFilters sets the filter pipeline applied after disassembly. Filters run
+// WithFilters sets the filter pipeline applied after disassembly. filters run
 // in the order provided. Pass no arguments to disable all filters.
 func WithFilters(filters ...CandidateFilter) Option {
 	return func(o *options) {
@@ -24,7 +24,8 @@ func WithFilters(filters ...CandidateFilter) Option {
 	}
 }
 
-// PLTFilter removes candidates that land inside linker-generated PLT sections.
+// PLTFilter removes candidates from cs that land inside linker-generated PLT
+// sections (.plt, .plt.got, .plt.sec, .iplt) as reported by f.
 func PLTFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error) {
 	var pltRanges [][2]uint64
 	for _, name := range []string{".plt", ".plt.got", ".plt.sec", ".iplt"} {
@@ -35,11 +36,11 @@ func PLTFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error)
 	return filterCandidatesInRanges(cs, pltRanges), nil
 }
 
-// CETFilter applies the CET-aware ENDBR64 filter on AMD64 ELF binaries.
-// Non-AMD64 binaries are returned unchanged. The filter must run before
-// EhFrameFilter so that any aligned-entry candidate it drops can be recovered
-// as DetectionCFI when its address appears in an FDE record (e.g. _start has
-// no ENDBR64 but does have an FDE entry).
+// CETFilter filters cs using the CET-aware ENDBR64 heuristic, reading the
+// .text section from f. Non-AMD64 binaries are returned unchanged. The filter
+// must run before EhFrameFilter so that any aligned-entry candidate it drops
+// can be recovered as DetectionCFI when its address appears in an FDE record
+// (e.g. _start has no ENDBR64 but does have an FDE entry).
 func CETFilter(cs []FunctionCandidate, f *elf.File) ([]FunctionCandidate, error) {
 	if f.Machine != elf.EM_X86_64 {
 		return cs, nil


### PR DESCRIPTION
This folows up #36 by documenting WithFilters, PLTFilter, CETFilter, EhFrameFilter, APIs and the opts argument of DetectFunctionsFromELF. Update README with the new signature, the filter options reference, and fix the stale DetectionBoth constant (renamed to DetectionPrologueCallSite in PR #33).