### PR TITLE
fix(dwarf): upgrade FDE-confirmed candidates to ConfidenceHigh

### DIFF
--- a/dwarf.go
+++ b/dwarf.go
@@ -67,6 +67,7 @@ func applyEhFrame(candidates []FunctionCandidate, fdeVAs []uint64) []FunctionCan
 	filtered := candidates[:0]
 	for _, c := range candidates {
 		if _, ok := fdeSet[c.Address]; ok {
+			c.Confidence = ConfidenceHigh
 			filtered = append(filtered, c)
 		}
 	}


### PR DESCRIPTION
Fixes #40

## Problem

`applyEhFrame` uses the `.eh_frame` FDE set as a whitelist but never upgrades the confidence of disassembly candidates that survive it. A candidate confirmed by both a disassembly heuristic and a compiler-emitted FDE entry ends up at `Medium`, while a FDE-only hit is hardcoded to `High`.

## Fix

Promote every candidate that passes the FDE whitelist to `ConfidenceHigh`. Compiler-emitted CFI data is the ground truth - confirmation by it should always yield the highest confidence regardless of what disassembly found.